### PR TITLE
create requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest
+file-processing-test-data @ git+https://github.com/hc-sc-ocdo-bdpd/file-processing-test-data.git@main
+file-processing-ocr @ git+https://github.com/hc-sc-ocdo-bdpd/file-processing-ocr.git@main
+file-processing-transcription @ git+https://github.com/hc-sc-ocdo-bdpd/file-processing-transcription.git@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pytest
 Pillow
 pillow_heif
 python_pptx
@@ -11,4 +10,3 @@ extract_msg
 pypdf
 striprtf
 ipykernel
-file-processing-test-data @ git+https://github.com/hc-sc-ocdo-bdpd/file-processing-test-data.git@main


### PR DESCRIPTION
- Split requirements files, so the user doesn't have to download 173mb from file-processing-test-data. 
- Also add file-processing-ocr and file-processing-transcription to requirements-dev so integration can be tested.